### PR TITLE
Add support for msvc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,24 @@ class MyBuildExt(build_ext):
             ext.sources.append(os.path.join(AMALGAMATION_ROOT, "sqlite3.c"))
             ext.include_dirs.append(AMALGAMATION_ROOT)
 
-            ext.extra_link_args.append("-lcrypto")
+            if sys.platform == "win32":
+                # Try to locate openssl
+                openssl_conf = os.environ.get('OPENSSL_CONF')
+                if not openssl_conf:
+                    sys.exit('Fatal error: OpenSSL could not be detected!') 
+                openssl = os.path.dirname(os.path.dirname(openssl_conf))
+
+                # Configure the compiler
+                ext.include_dirs.append(os.path.join(openssl, "include"))
+                ext.define_macros.append(("inline", "__inline"))
+
+                # Configure the linker
+                ext.extra_link_args.append("libeay32.lib")
+                ext.extra_link_args.append(
+                    "/LIBPATH:" + os.path.join(openssl, "lib")
+                )
+            else:
+                ext.extra_link_args.append("-lcrypto")
 
         if self.static:
             self._build_extension(ext)


### PR DESCRIPTION
#### Motivation

In the OpenBazaar project we use pysqlcipher and we are preparing a build for Windows. We would like to be able to use Visual Studio to compile pysqlcipher for Windows instead of using cygwin with mingw. Most of our dependencies support compilation with  Visual Studio but pysqlcipher doesn't. 
#### Fix

In this patch I have added a check for the win32 platform. When win32 platform is detected the parameters of the compiler and linker are altered in order to let visual studio compile pysqlcipher. The first step is to detect OpenSSL by checking an environment variable that is set when OpenSSL is installed. Then the directories include and lib of the openssl directory are passed to the compiler and the linker. In Windows libcrypto of OpenSSL is called libeay32, so pysqlcipher should link to libeay32.lib.
It should be also noted here that amalgamation.c doesn't compile out of the box with Visual Studio so this patch also adds a define that allows the compiler to work fine.
