### PR TITLE
[feat] enable usleep

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,4 @@ libraries=sqlcipher
 #include_dirs=/usr/local/include
 #library_dirs=/usr/local/lib
 #define=SQLITE_OMIT_LOAD_EXTENSION
+define=HAVE_USLEEP


### PR DESCRIPTION
From https://www.sqlite.org/compile.html

    HAVE_USLEEP

    If the HAVE_USLEEP option is true, then the default unix VFS uses the
    usleep() system call to implement the xSleep method. If this option is
    undefined or false, then xSleep on unix is implemented using sleep() which
    means that sqlite3_sleep() will have a minimum wait interval of 1000
    milliseconds regardless of its argument.

Not having that flag set means that attempts to write to a locked database
sleep for integer amount of seconds, which may increase the probability of
OperationalError exceptions.