### PR TITLE
Change the libraries hack in the setup.py to only ignore sqlcipher/sqlite3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -182,8 +182,12 @@ class AmalgamationBuildExt(build_ext):
     def __setattr__(self, k, v):
         # Make sure we don't link against the SQLite
         # library, no matter what setup.cfg says
-        if self.amalgamation and k == "libraries":
-            v = None
+        if self.amalgamation and k == "libraries" and isinstance(v, list):
+            for i in ["sqlcipher", "sqlite3"]:
+                try:
+                    v.remove(i)
+                except ValueError:
+                    pass
         self.__dict__[k] = v
 
 


### PR DESCRIPTION
Sometimes it's necessary to link with additional libraries like when static linking OpenSSL on Windows. The previous hack made this impossible without modifying the setup.py when using `--bundled`/`--amalgamation`.