### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ if PYSQLITE_EXPERIMENTAL:
 if sys.platform == "darwin":
     # Work around clang raising hard error for unused arguments
     os.environ['CFLAGS'] = "-Qunused-arguments"
-    print "CFLAGS", os.environ['CFLAGS']
+    print("CFLAGS", os.environ['CFLAGS'])
 
 include_dirs = []
 library_dirs = []


### PR DESCRIPTION
Refactored to resolve syntax error, with missing parenthesis during egg installation.

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [7 lines of output]
      Traceback (most recent call last):
        File "<string>", line 36, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-p3t045mx/pysqlcipher_0057c16bd8cf407782aa9e6618077d88/setup.py", line 64
          print "CFLAGS", os.environ['CFLAGS']
                       ^
      SyntaxError: Missing parentheses in call to 'print'. Did you mean print("CFLAGS", os.environ['CFLAGS'])?
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

Reproduced here
    print "CFLAGS", os_env
          ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("CFLAGS", os_env)?

Resolution
print("CFLAGS", os_env)
CFLAGS -Qunused-arguments